### PR TITLE
Add support for getLoginAccounts

### DIFF
--- a/lib/aggcat/client.rb
+++ b/lib/aggcat/client.rb
@@ -52,6 +52,11 @@ module Aggcat
       get(path)
     end
 
+    def login_accounts(login_id)
+      validate(login_id: login_id)
+      get("/logins/#{login_id}/accounts")
+    end
+
     def update_login(institution_id, login_id, username, password)
       validate(institution_id: institution_id, login_id: login_id, username: username, password: password)
       body = credentials(institution_id, username, password)

--- a/test/aggcat/client_test.rb
+++ b/test/aggcat/client_test.rb
@@ -150,6 +150,20 @@ class ClientTest < Test::Unit::TestCase
     assert_nil @client.instance_variable_get('@oauth_token')
   end
 
+  def test_login_accounts
+    login_id = '147630161'
+    stub_get("/logins/#{login_id}/accounts").to_return(:body => fixture('accounts.xml'), :headers => {:content_type => 'application/xml; charset=utf-8'})
+    response = @client.login_accounts(login_id)
+    assert_equal '200', response[:status_code]
+  end
+
+  def test_login_accounts_bad_args
+    [nil, ''].each do |arg|
+      exception = assert_raise(ArgumentError) { @client.login_accounts(arg) }
+      assert_equal('login_id is required', exception.message)
+    end
+  end
+
   def test_update_login
     institution_id = '100000'
     login_id = '12345'


### PR DESCRIPTION
Our account representative provided us with the following flow chart for adding user's cards to our system:

![intuit_flow_chart](https://f.cloud.github.com/assets/816048/1602687/565da964-539c-11e3-9a1b-76c15af2c326.jpg)

This PR adds support for the missing `getLoginAccounts` call found in the diagram.

You'll notice both in the specs and live behavior that the response is the same as the call to `discoverAndAddAccounts` - from my understanding the difference is on Intuit's end.

Please let me know if you have any questions.

Thanks for producing such a great gem, it's saved our team a ton of time!
