### PR TITLE
Add support for updateAccountType

### DIFF
--- a/lib/aggcat/base.rb
+++ b/lib/aggcat/base.rb
@@ -16,6 +16,11 @@ module Aggcat
 
     LOGIN_NAMESPACE = 'http://schema.intuit.com/platform/fdatafeed/institutionlogin/v1'
     CHALLENGE_NAMESPACE = 'http://schema.intuit.com/platform/fdatafeed/challenge/v1'
+    BANKING_ACCOUNT_NAMESPACE = 'http://schema.intuit.com/platform/fdatafeed/bankingaccount/v1'
+    CREDIT_ACCOUNT_NAMESPACE = 'http://schema.intuit.com/platform/fdatafeed/creditaccount/v1'
+    LOAN_NAMESPACE = 'http://schema.intuit.com/platform/fdatafeed/loan/v1'
+    INVESTMENT_ACCOUNT_NAMESPACE = 'http://schema.intuit.com/platform/fdatafeed/investmentaccount/v1'
+    REWARD_ACCOUNT_NAMESPACE = 'http://schema.intuit.com/platform/fdatafeed/rewardsaccount/v1'
 
     TIME_FORMAT = '%Y-%m-%dT%T.%LZ'
     DATE_FORMAT = '%Y-%m-%d'

--- a/lib/aggcat/client.rb
+++ b/lib/aggcat/client.rb
@@ -69,6 +69,12 @@ module Aggcat
       put("/logins/#{login_id}?refresh=true", challenge_answers(answers), headers)
     end
 
+    def update_account_type(account_id, type)
+      validate(account_id: account_id, type: type)
+      body = account_type(type)
+      put("/accounts/#{account_id}", body)
+    end
+
     def delete_account(account_id)
       validate(account_id: account_id)
       delete("/accounts/#{account_id}")
@@ -161,6 +167,30 @@ module Aggcat
       end
     end
 
+    def account_type(type)
+      xml = Builder::XmlMarkup.new
+      if ['CHECKING', 'SAVINGS', 'MONEYMRKT', 'RECURRINGDEPOSIT', 'CD', 'CASHMANAGEMENT', 'OVERDRAFT'].include?(type)
+        xml.tag!('ns4:BankingAccount', {'xmlns:ns4' => BANKING_ACCOUNT_NAMESPACE}) do
+          xml.tag!('ns4:bankingAccountType', type)
+        end
+      elsif ['CREDITCARD', 'LINEOFCREDIT', 'OTHER'].include?(type)
+        xml.tag!('ns4:CreditAccount', {'xmlns:ns4' => CREDIT_ACCOUNT_NAMESPACE}) do
+          xml.tag!('ns4:creditAccountType', type)
+        end
+      elsif ['LOAN', 'AUTO', 'COMMERCIAL', 'CONSTR', 'CONSUMER', 'HOMEEQUITY', 'MILITARY', 'MORTGAGE', 'SMB', 'STUDENT'].include?(type)
+        xml.tag!('ns4:Loan', {'xmlns:ns4' => LOAN_NAMESPACE}) do
+          xml.tag!('ns4:loanType', type)
+        end
+      elsif ['TAXABLE', '401K', 'BROKERAGE', 'IRA', '403B', 'KEOGH', 'TRUST', 'TDA', 'SIMPLE', 'NORMAL', 'SARSEP', 'UGMA', 'OTHER'].include?(type)
+        xml.tag!('ns4:InvestmentAccount', {'xmlns:ns4' => INVESTMENT_ACCOUNT_NAMESPACE}) do
+          xml.tag!('ns4:investmentAccountType', type)
+        end
+      else
+        xml.tag!('ns4:RewardAccount', {'xmlns:ns4' => REWARD_ACCOUNT_NAMESPACE}) do
+          xml.tag!('ns4:rewardAccountType')
+        end
+      end
+    end
   end
 end
 

--- a/test/aggcat/client_test.rb
+++ b/test/aggcat/client_test.rb
@@ -128,6 +128,24 @@ class ClientTest < Test::Unit::TestCase
     end
   end
 
+  def test_update_account_type
+    account_id = '000000000001'
+    type = 'ANOTHER'
+    stub_put("/accounts/#{account_id}").to_return(:status => 200)
+    response = @client.update_account_type(account_id, type)
+    assert_equal '200', response[:status_code]
+  end
+
+  def test_update_account_type_bad_args
+    [nil, ''].each do |arg|
+      exception = assert_raise(ArgumentError) { @client.update_account_type(arg, 'CREDITCARD') }
+      assert_equal('account_id is required', exception.message)
+
+      exception = assert_raise(ArgumentError) { @client.update_account_type(1, arg) }
+      assert_equal('type is required', exception.message)
+    end
+  end
+
   def test_delete_account
     account_id = '000000000001'
     stub_delete("/accounts/#{account_id}").to_return(:status => 200)


### PR DESCRIPTION
Our account representative let us know that sometimes an account can fall into an 'OTHER' category. In this case they will not be able to get transactional data for the account, but all aggregation dates and codes look to be valid. 

This PR adds support for the updateAccountType call in order to categorize the 'other' accounts. Intuit's documentation on the call can be found here:

https://developer.intuit.com/docs/0020_customeraccountdata/customer_account_data_api/0020_api_documentation/0070_updateaccounttype

Please let me know if you have any questions.
