### PR TITLE
Add specs to test multiple credential field submits

### DIFF
--- a/lib/aggcat/client.rb
+++ b/lib/aggcat/client.rb
@@ -139,7 +139,7 @@ module Aggcat
       institution_login_keys = institution[:result][:institution_detail][:keys][:key].sort { |a, b| a[:display_order].to_i <=> b[:display_order].to_i }
 
       if institution_login_keys.length != login_credentials.length
-        raise ArgumentError.new("institution_id #{institution_id} requires #{institution_login_keys.length} credential fields but was only given #{login_credentials.length} to authenticate with.")
+        raise ArgumentError.new("institution_id #{institution_id} requires #{institution_login_keys.length} credential fields but was given #{login_credentials.length} to authenticate with.")
       end
 
       hash = {}

--- a/test/fixtures/institution_three_credentials.xml
+++ b/test/fixtures/institution_three_credentials.xml
@@ -1,0 +1,51 @@
+<InstitutionDetail xmlns="http://schema.intuit.com/platform/fdatafeed/account/v1"
+                   xmlns:ns2="http://schema.intuit.com/platform/fdatafeed/common/v1">
+  <institutionId>100000</institutionId>
+  <institutionName>CCBank</institutionName>
+  <homeUrl>http://www.example.com</homeUrl>
+  <phoneNumber>123-456-7890</phoneNumber>
+  <address>
+    <ns2:address1>100 Main Street</ns2:address1>
+    <ns2:city>Anytown</ns2:city>
+    <ns2:state>CA</ns2:state>
+    <ns2:postalCode>94043</ns2:postalCode>
+    <ns2:country>USA</ns2:country>
+  </address>
+  <emailAddress>CustomerCentralBank@intuit.com</emailAddress>
+  <currencyCode>ANG</currencyCode>
+  <keys>
+    <key>
+      <name>Banking Userid</name>
+      <status>Active</status>
+      <valueLengthMin>1</valueLengthMin>
+      <valueLengthMax>100</valueLengthMax>
+      <displayFlag>true</displayFlag>
+      <displayOrder>1</displayOrder>
+      <mask>false</mask>
+      <instructions>2</instructions>
+      <description>2</description>
+    </key>
+    <key>
+      <name>Banking Password</name>
+      <status>Active</status>
+      <valueLengthMin>1</valueLengthMin>
+      <valueLengthMax>100</valueLengthMax>
+      <displayFlag>false</displayFlag>
+      <displayOrder>2</displayOrder>
+      <mask>true</mask>
+      <instructions>2</instructions>
+      <description>2</description>
+    </key>
+    <key>
+      <name>Account pin</name>
+      <status>Active</status>
+      <valueLengthMin>1</valueLengthMin>
+      <valueLengthMax>100</valueLengthMax>
+      <displayFlag>false</displayFlag>
+      <displayOrder>3</displayOrder>
+      <mask>true</mask>
+      <instructions>2</instructions>
+      <description>2</description>
+    </key>
+  </keys>
+</InstitutionDetail>


### PR DESCRIPTION
Here are a few specs to test multiple credential submission successes and failures for the discover and add as well as updates to login credentials. Let me know if you'd like me to add / tweak anything else.
