### PR TITLE
make the second argument of discover_and_add_accounts a Hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ client.institutions
 client.institution(14007)
 
 # add new financial account to aggregate from Bank of America
-response = client.discover_and_add_accounts(14007, username, password)
+# the second argument is a Hash of the required fields specified in the client.institution() response
+response = client.discover_and_add_accounts(14007, {'key1'=>'value1','key2'=>'value2','key3'=>'value3'})
 
 # in case MFA is required
 questions = response[:result][:challenges]

--- a/lib/aggcat/client.rb
+++ b/lib/aggcat/client.rb
@@ -22,9 +22,9 @@ module Aggcat
       get("/institutions/#{institution_id}")
     end
 
-    def discover_and_add_accounts(institution_id, *login_credentials)
-      validate(institution_id: institution_id, username: login_credentials[0], password: login_credentials[1])
-      body = credentials(institution_id, login_credentials)
+    def discover_and_add_accounts(institution_id, login_credentials={})
+      validate(institution_id: institution_id)
+      body = credentials(login_credentials)
       post("/institutions/#{institution_id}/logins", body)
     end
 
@@ -57,9 +57,9 @@ module Aggcat
       get("/logins/#{login_id}/accounts")
     end
 
-    def update_login(institution_id, login_id, *login_credentials)
-      validate(institution_id: institution_id, login_id: login_id, username: login_credentials[0], password: login_credentials[1])
-      body = credentials(institution_id, login_credentials)
+    def update_login(institution_id, login_id, login_credentials={})
+      validate(institution_id: institution_id, login_id: login_id)
+      body = credentials(login_credentials)
       put("/logins/#{login_id}?refresh=true", body)
     end
 
@@ -138,20 +138,11 @@ module Aggcat
       end
     end
 
-    def credentials(institution_id, login_credentials)
-      institution = institution(institution_id)
-      raise ArgumentError.new("institution_id #{institution_id} is invalid") if institution.nil? || institution[:result][:institution_detail].nil?
-      login_keys = institution[:result][:institution_detail][:keys][:key].select { |key| key[:display_flag] == 'true' }.sort { |a, b| a[:display_order].to_i <=> b[:display_order].to_i }
-      if login_keys.length != login_credentials.length
-        raise ArgumentError.new("institution_id #{institution_id} requires #{login_keys.length} credential fields but was given #{login_credentials.length} to authenticate with.")
-      end
-
-      hash = login_keys.each_with_index.inject({}) { |h, (key, index)| h[key[:name]] = login_credentials[index].to_s; h }
-
+    def credentials(login_credentials={})
       xml = Builder::XmlMarkup.new
       xml.InstitutionLogin('xmlns' => LOGIN_NAMESPACE) do |login|
         login.credentials('xmlns:ns1' => LOGIN_NAMESPACE) do
-          hash.each do |key, value|
+          login_credentials.each do |key, value|
             xml.tag!('ns1:credential', {'xmlns:ns2' => LOGIN_NAMESPACE}) do
               xml.tag!('ns2:name', key)
               xml.tag!('ns2:value', value)
@@ -198,5 +189,3 @@ module Aggcat
     end
   end
 end
-
-

--- a/test/aggcat/client_test.rb
+++ b/test/aggcat/client_test.rb
@@ -47,7 +47,7 @@ class ClientTest < Test::Unit::TestCase
     institution_id = '100000'
     stub_get("/institutions/#{institution_id}").to_return(:body => fixture('institution.xml'), :headers => {:content_type => 'application/xml; charset=utf-8'})
     stub_post("/institutions/#{institution_id}/logins").to_return(:body => fixture('account.xml'), :headers => {:content_type => 'application/xml; charset=utf-8'})
-    response = @client.discover_and_add_accounts(institution_id, 'username', 'password')
+    response = @client.discover_and_add_accounts(institution_id, {:username=>'username', :password=>'password'})
     assert_equal institution_id, response[:result][:account_list][:banking_account][:institution_id]
     assert_equal '000000000001', response[:result][:account_list][:banking_account][:account_id]
   end
@@ -56,7 +56,7 @@ class ClientTest < Test::Unit::TestCase
     institution_id = '100000'
     stub_get("/institutions/#{institution_id}").to_return(:body => fixture('institution_hidden_fields.xml'), :headers => {:content_type => 'application/xml; charset=utf-8'})
     stub_post("/institutions/#{institution_id}/logins").to_return(:body => fixture('account.xml'), :headers => {:content_type => 'application/xml; charset=utf-8'})
-    response = @client.discover_and_add_accounts(institution_id, 'username', 'password')
+    response = @client.discover_and_add_accounts(institution_id, {:username=>'username', :password=>'password'})
     assert_equal institution_id, response[:result][:account_list][:banking_account][:institution_id]
     assert_equal '000000000001', response[:result][:account_list][:banking_account][:account_id]
   end
@@ -64,8 +64,8 @@ class ClientTest < Test::Unit::TestCase
   def test_discover_and_add_accounts_with_challenge
     institution_id = '100000'
     stub_get("/institutions/#{institution_id}").to_return(:body => fixture('institution.xml'), :headers => {:content_type => 'application/xml; charset=utf-8'})
-    stub_post("/institutions/#{institution_id}/logins").to_return(:code => 401, :body => fixture('account.xml'), :headers => {:content_type => 'application/xml; charset=utf-8'})
-    response = @client.discover_and_add_accounts(institution_id, 'username', 'password')
+    stub_post("/institutions/#{institution_id}/logins").to_return(:status => 401, :body => fixture('account.xml'), :headers => {:content_type => 'application/xml; charset=utf-8'})
+    response = @client.discover_and_add_accounts(institution_id, {:username=>'username', :password=>'password'})
     assert_equal institution_id, response[:result][:account_list][:banking_account][:institution_id]
     assert_equal '000000000001', response[:result][:account_list][:banking_account][:account_id]
   end
@@ -74,28 +74,15 @@ class ClientTest < Test::Unit::TestCase
     institution_id = '100000'
     stub_get("/institutions/#{institution_id}").to_return(:body => fixture('institution_three_credentials.xml'), :headers => {:content_type => 'application/xml; charset=utf-8'})
     stub_post("/institutions/#{institution_id}/logins").to_return(:body => fixture('account.xml'), :headers => {:content_type => 'application/xml; charset=utf-8'})
-    response = @client.discover_and_add_accounts(institution_id, 'username', 'password', 'account pin')
+    response = @client.discover_and_add_accounts(institution_id, {:username=>'username', :password=>'password', 'account pin'=>'1234'})
     assert_equal institution_id, response[:result][:account_list][:banking_account][:institution_id]
     assert_equal '000000000001', response[:result][:account_list][:banking_account][:account_id]
   end
 
-  def test_discover_and_add_accounts_not_enough_credentials
-    institution_id = '100000'
-    stub_get("/institutions/#{institution_id}").to_return(:body => fixture('institution_three_credentials.xml'), :headers => {:content_type => 'application/xml; charset=utf-8'})
-    exception = assert_raise(ArgumentError) { @client.discover_and_add_accounts(institution_id, 'username', 'password') }
-    assert_equal('institution_id 100000 requires 3 credential fields but was given 2 to authenticate with.', exception.message)
-  end
-
   def test_discover_and_add_accounts_bad_args
     [nil, ''].each do |arg|
-      exception = assert_raise(ArgumentError) { @client.discover_and_add_accounts(arg, 'username', 'password') }
+      exception = assert_raise(ArgumentError) { @client.discover_and_add_accounts(arg, {:username=>'username', :password=>'password'}) }
       assert_equal('institution_id is required', exception.message)
-
-      exception = assert_raise(ArgumentError) { @client.discover_and_add_accounts(1, arg, 'password') }
-      assert_equal('username is required', exception.message)
-
-      exception = assert_raise(ArgumentError) { @client.discover_and_add_accounts(1, 'username', arg) }
-      assert_equal('password is required', exception.message)
     end
   end
 
@@ -212,7 +199,7 @@ class ClientTest < Test::Unit::TestCase
     login_id = '12345'
     stub_get("/institutions/#{institution_id}").to_return(:body => fixture('institution.xml'), :headers => {:content_type => 'application/xml; charset=utf-8'})
     stub_put("/logins/#{login_id}?refresh=true").to_return(:status => 200)
-    response = @client.update_login(institution_id, login_id, 'usename', 'password')
+    response = @client.update_login(institution_id, login_id, {:username=>'username', :password=>'password'})
     assert_equal '200', response[:status_code]
   end
 
@@ -221,31 +208,14 @@ class ClientTest < Test::Unit::TestCase
     login_id = '12345'
     stub_get("/institutions/#{institution_id}").to_return(:body => fixture('institution_three_credentials.xml'), :headers => {:content_type => 'application/xml; charset=utf-8'})
     stub_put("/logins/#{login_id}?refresh=true").to_return(:status => 200)
-    response = @client.update_login(institution_id, login_id, 'usename', 'password', 'account pin')
+    response = @client.update_login(institution_id, login_id, {:username=>'username', :password=>'password', 'account pin'=>'1234'})
     assert_equal '200', response[:status_code]
-  end
-
-  def test_update_login_not_enough_credentials
-    institution_id = '100000'
-    login_id = '12345'
-    stub_get("/institutions/#{institution_id}").to_return(:body => fixture('institution_three_credentials.xml'), :headers => {:content_type => 'application/xml; charset=utf-8'})
-    exception = assert_raise(ArgumentError) { @client.update_login(institution_id, login_id, 'username', 'password') }
-    assert_equal('institution_id 100000 requires 3 credential fields but was given 2 to authenticate with.', exception.message)
   end
 
   def test_update_login_bad_args
     [nil, ''].each do |arg|
-      exception = assert_raise(ArgumentError) { @client.update_login(arg, 1, 'username', 'password') }
+      exception = assert_raise(ArgumentError) { @client.update_login(arg, 1, {:username=>'username', :password=>'password'}) }
       assert_equal('institution_id is required', exception.message)
-
-      exception = assert_raise(ArgumentError) { @client.update_login(1, arg, 'username', 'password') }
-      assert_equal('login_id is required', exception.message)
-
-      exception = assert_raise(ArgumentError) { @client.update_login(1, 1, arg, 'password') }
-      assert_equal('username is required', exception.message)
-
-      exception = assert_raise(ArgumentError) { @client.update_login(1, 1, 'username', arg) }
-      assert_equal('password is required', exception.message)
     end
   end
 


### PR DESCRIPTION
It doesn't really make sense to force a "username" and "password" paradigm for discover_and_add_accounts since the request has to be a Hash with keys that are provided by the institution details. It's better to accept a Hash with key/value because

1) You can supply as many keys as required by the institution
2) Eliminate the unnecessary call to get institution details on discover_and_add_accounts
3) Eliminate the need to assemble a key/value hash based on "display_order". I can see this failing if display_order does not match up with "username" and "password"
4) Many institutions have different login requirements other than "username" / "password". Which means to properly collect this information from the user, you should be already providing them with the correct "key".

This is a destructive commit that will be incompatible with prior versions. I think improvements could be made to my changes, but I think the concept of accepting a Hash of keys and values should be used going forward.

