### PR TITLE
Added ability to target Finicity Facade API

### DIFF
--- a/lib/aggcat/base.rb
+++ b/lib/aggcat/base.rb
@@ -77,7 +77,7 @@ module Aggcat
       signature_value = Base64.encode64(key.sign(OpenSSL::Digest::SHA1.new(nil), signed_info)).gsub(/\n/, '')
       signature = %[<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/><ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/><ds:Reference URI="#_#{reference_id}"><ds:Transforms><ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/><ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/></ds:Transforms><ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/><ds:DigestValue>#{digest}</ds:DigestValue></ds:Reference></ds:SignedInfo><ds:SignatureValue>#{signature_value}</ds:SignatureValue></ds:Signature>]
       assertion_with_signature = assertion.sub(/saml2:Issuer\>\<saml2:Subject/, "saml2:Issuer>#{signature}<saml2:Subject")
-      Base64.encode64(assertion_with_signature)
+      Base64.strict_encode64(assertion_with_signature)
     end
 
     def certificate

--- a/lib/aggcat/base.rb
+++ b/lib/aggcat/base.rb
@@ -54,7 +54,7 @@ module Aggcat
     end
 
     def new_token(message)
-      uri = URI.parse(SAML_URL)
+      uri = URI.parse(@oauth_url)
       http = Net::HTTP.new(uri.host, uri.port)
       request = Net::HTTP::Post.new(uri.request_uri)
       request['Authorization'] = %[OAuth oauth_consumer_key="#{@consumer_key}"]

--- a/lib/aggcat/client.rb
+++ b/lib/aggcat/client.rb
@@ -5,6 +5,8 @@ module Aggcat
 
     def initialize(options={})
       raise ArgumentError.new('customer_id is required for scoping all requests') if options[:customer_id].nil? || options[:customer_id].to_s.empty?
+      options[:oauth_url] ||= SAML_URL
+      options[:base_url] ||= BASE_URL
       options[:open_timeout] ||= OPEN_TIMEOUT
       options[:read_timeout] ||= READ_TIMEOUT
       options[:verbose] ||= false
@@ -200,5 +202,3 @@ module Aggcat
     end
   end
 end
-
-

--- a/lib/aggcat/client.rb
+++ b/lib/aggcat/client.rb
@@ -117,7 +117,7 @@ module Aggcat
     def request(http_method, path, *options)
       tries = 0
       begin
-        response = oauth_client.send(http_method, BASE_URL + path, *options)
+        response = oauth_client.send(http_method, @base_url + path, *options)
         result = {:status_code => response.code, :result => parse_xml(response.body)}
         if response['challengeSessionId']
           result[:challenge_session_id] = response['challengeSessionId']

--- a/lib/aggcat/configurable.rb
+++ b/lib/aggcat/configurable.rb
@@ -1,7 +1,7 @@
 module Aggcat
   module Configurable
 
-    KEYS = [:issuer_id, :consumer_key, :consumer_secret, :certificate_value, :certificate_password, :certificate_path, :customer_id, :open_timeout, :read_timeout, :verbose]
+    KEYS = [:oauth_url, :base_url, :issuer_id, :consumer_key, :consumer_secret, :certificate_value, :certificate_password, :certificate_path, :customer_id, :open_timeout, :read_timeout, :verbose]
 
     attr_writer *KEYS
 

--- a/test/aggcat/aggcat_test.rb
+++ b/test/aggcat/aggcat_test.rb
@@ -1,10 +1,13 @@
 require 'test_helper'
 
 class AggcatTest < Test::Unit::TestCase
+  OAUTH_URL = Aggcat::Base::SAML_URL
+  BASE_URL = Aggcat::Client::BASE_URL
+
   def setup
     Aggcat.configure do |config|
-      config.oauth_url = 'oauth_url'
-      config.base_url = 'base_url'
+      config.oauth_url = OAUTH_URL
+      config.base_url = BASE_URL
       config.issuer_id = 'issuer_id'
       config.consumer_key = 'consumer_key'
       config.consumer_secret = 'consumer_secret'
@@ -14,8 +17,8 @@ class AggcatTest < Test::Unit::TestCase
 
   def test_configure
     configurable = Aggcat.configure do |config|
-      config.oauth_url = 'oauth_url'
-      config.base_url = 'base_url'
+      config.oauth_url = OAUTH_URL
+      config.base_url = BASE_URL
       config.issuer_id = 'issuer_id'
       config.consumer_key = 'consumer_key'
       config.consumer_secret = 'consumer_secret'
@@ -23,8 +26,8 @@ class AggcatTest < Test::Unit::TestCase
       config.open_timeout = 5
       config.read_timeout = 30
     end
-    assert_equal 'oauth_url', configurable.instance_variable_get(:'@oauth_url')
-    assert_equal 'base_url', configurable.instance_variable_get(:'@base_url')
+    assert_equal OAUTH_URL, configurable.instance_variable_get(:'@oauth_url')
+    assert_equal BASE_URL, configurable.instance_variable_get(:'@base_url')
     assert_equal 'issuer_id', configurable.instance_variable_get(:'@issuer_id')
     assert_equal 'consumer_key', configurable.instance_variable_get(:'@consumer_key')
     assert_equal 'consumer_secret', configurable.instance_variable_get(:'@consumer_secret')
@@ -36,8 +39,8 @@ class AggcatTest < Test::Unit::TestCase
   def test_configure_certificate_by_value
     cert_value = File.read("#{fixture_path}/cert.key")
     configurable = Aggcat.configure do |config|
-      config.oauth_url = 'oauth_url'
-      config.base_url = 'base_url'
+      config.oauth_url = OAUTH_URL
+      config.base_url = BASE_URL
       config.issuer_id = 'issuer_id'
       config.consumer_key = 'consumer_key'
       config.consumer_secret = 'consumer_secret'
@@ -45,8 +48,8 @@ class AggcatTest < Test::Unit::TestCase
       config.open_timeout = 5
       config.read_timeout = 30
     end
-    assert_equal 'oauth_url', configurable.instance_variable_get(:'@oauth_url')
-    assert_equal 'base_url', configurable.instance_variable_get(:'@base_url')
+    assert_equal OAUTH_URL, configurable.instance_variable_get(:'@oauth_url')
+    assert_equal BASE_URL, configurable.instance_variable_get(:'@base_url')
     assert_equal 'issuer_id', configurable.instance_variable_get(:'@issuer_id')
     assert_equal 'consumer_key', configurable.instance_variable_get(:'@consumer_key')
     assert_equal 'consumer_secret', configurable.instance_variable_get(:'@consumer_secret')
@@ -58,16 +61,16 @@ class AggcatTest < Test::Unit::TestCase
   def test_configure_certificate_with_password
     cert_value = File.read("#{fixture_path}/cert.key")
     configurable = Aggcat.configure do |config|
-      config.oauth_url = 'oauth_url'
-      config.base_url = 'base_url'
+      config.oauth_url = OAUTH_URL
+      config.base_url = BASE_URL
       config.issuer_id = 'issuer_id'
       config.consumer_key = 'consumer_key'
       config.consumer_secret = 'consumer_secret'
       config.certificate_value = cert_value
       config.certificate_password = 'cert_password'
     end
-    assert_equal 'oauth_url', configurable.instance_variable_get(:'@oauth_url')
-    assert_equal 'base_url', configurable.instance_variable_get(:'@base_url')
+    assert_equal OAUTH_URL, configurable.instance_variable_get(:'@oauth_url')
+    assert_equal BASE_URL, configurable.instance_variable_get(:'@base_url')
     assert_equal 'issuer_id', configurable.instance_variable_get(:'@issuer_id')
     assert_equal 'consumer_key', configurable.instance_variable_get(:'@consumer_key')
     assert_equal 'consumer_secret', configurable.instance_variable_get(:'@consumer_secret')
@@ -78,8 +81,8 @@ class AggcatTest < Test::Unit::TestCase
   def test_scope
     client1 = Aggcat.scope('1')
     assert_true client1.is_a?(Aggcat::Client)
-    assert_equal 'oauth_url', client1.instance_variable_get(:'@oauth_url')
-    assert_equal 'base_url', client1.instance_variable_get(:'@base_url')
+    assert_equal OAUTH_URL, client1.instance_variable_get(:'@oauth_url')
+    assert_equal BASE_URL, client1.instance_variable_get(:'@base_url')
     assert_equal 'issuer_id', client1.instance_variable_get(:'@issuer_id')
     assert_equal 'consumer_key', client1.instance_variable_get(:'@consumer_key')
     assert_equal 'consumer_secret', client1.instance_variable_get(:'@consumer_secret')
@@ -99,7 +102,7 @@ class AggcatTest < Test::Unit::TestCase
   end
 
   def test_client_api
-    stub_request(:post, Aggcat::Base::SAML_URL).to_return(:status => 200, :body => fixture('oauth_token.txt'))
+    stub_request(:post, OAUTH_URL).to_return(:status => 200, :body => fixture('oauth_token.txt'))
     Aggcat.scope('1')
     stub_get('/institutions').to_return(:body => fixture('institutions.xml'), :headers => {:content_type => 'application/xml; charset=utf-8'})
     response = Aggcat.institutions

--- a/test/aggcat/aggcat_test.rb
+++ b/test/aggcat/aggcat_test.rb
@@ -3,6 +3,8 @@ require 'test_helper'
 class AggcatTest < Test::Unit::TestCase
   def setup
     Aggcat.configure do |config|
+      config.oauth_url = 'oauth_url'
+      config.base_url = 'base_url'
       config.issuer_id = 'issuer_id'
       config.consumer_key = 'consumer_key'
       config.consumer_secret = 'consumer_secret'
@@ -12,6 +14,8 @@ class AggcatTest < Test::Unit::TestCase
 
   def test_configure
     configurable = Aggcat.configure do |config|
+      config.oauth_url = 'oauth_url'
+      config.base_url = 'base_url'
       config.issuer_id = 'issuer_id'
       config.consumer_key = 'consumer_key'
       config.consumer_secret = 'consumer_secret'
@@ -19,6 +23,8 @@ class AggcatTest < Test::Unit::TestCase
       config.open_timeout = 5
       config.read_timeout = 30
     end
+    assert_equal 'oauth_url', configurable.instance_variable_get(:'@oauth_url')
+    assert_equal 'base_url', configurable.instance_variable_get(:'@base_url')
     assert_equal 'issuer_id', configurable.instance_variable_get(:'@issuer_id')
     assert_equal 'consumer_key', configurable.instance_variable_get(:'@consumer_key')
     assert_equal 'consumer_secret', configurable.instance_variable_get(:'@consumer_secret')
@@ -30,6 +36,8 @@ class AggcatTest < Test::Unit::TestCase
   def test_configure_certificate_by_value
     cert_value = File.read("#{fixture_path}/cert.key")
     configurable = Aggcat.configure do |config|
+      config.oauth_url = 'oauth_url'
+      config.base_url = 'base_url'
       config.issuer_id = 'issuer_id'
       config.consumer_key = 'consumer_key'
       config.consumer_secret = 'consumer_secret'
@@ -37,6 +45,8 @@ class AggcatTest < Test::Unit::TestCase
       config.open_timeout = 5
       config.read_timeout = 30
     end
+    assert_equal 'oauth_url', configurable.instance_variable_get(:'@oauth_url')
+    assert_equal 'base_url', configurable.instance_variable_get(:'@base_url')
     assert_equal 'issuer_id', configurable.instance_variable_get(:'@issuer_id')
     assert_equal 'consumer_key', configurable.instance_variable_get(:'@consumer_key')
     assert_equal 'consumer_secret', configurable.instance_variable_get(:'@consumer_secret')
@@ -48,12 +58,16 @@ class AggcatTest < Test::Unit::TestCase
   def test_configure_certificate_with_password
     cert_value = File.read("#{fixture_path}/cert.key")
     configurable = Aggcat.configure do |config|
+      config.oauth_url = 'oauth_url'
+      config.base_url = 'base_url'
       config.issuer_id = 'issuer_id'
       config.consumer_key = 'consumer_key'
       config.consumer_secret = 'consumer_secret'
       config.certificate_value = cert_value
       config.certificate_password = 'cert_password'
     end
+    assert_equal 'oauth_url', configurable.instance_variable_get(:'@oauth_url')
+    assert_equal 'base_url', configurable.instance_variable_get(:'@base_url')
     assert_equal 'issuer_id', configurable.instance_variable_get(:'@issuer_id')
     assert_equal 'consumer_key', configurable.instance_variable_get(:'@consumer_key')
     assert_equal 'consumer_secret', configurable.instance_variable_get(:'@consumer_secret')
@@ -64,6 +78,8 @@ class AggcatTest < Test::Unit::TestCase
   def test_scope
     client1 = Aggcat.scope('1')
     assert_true client1.is_a?(Aggcat::Client)
+    assert_equal 'oauth_url', client1.instance_variable_get(:'@oauth_url')
+    assert_equal 'base_url', client1.instance_variable_get(:'@base_url')
     assert_equal 'issuer_id', client1.instance_variable_get(:'@issuer_id')
     assert_equal 'consumer_key', client1.instance_variable_get(:'@consumer_key')
     assert_equal 'consumer_secret', client1.instance_variable_get(:'@consumer_secret')


### PR DESCRIPTION
Finicity has release a new "Facade" that mirrors Intuits, as Intuit is leaving the third party aggregation business. ([More Info](https://developer.intuit.com/hub/blog/2016/03/15/intuit-financial-data-apis-cad-update)) 

This PR allows the client to use the Finicity Facade API instead of the Intuit API.

The following parameters need to be added to the Client config
   * oauth_url: 'https://api.finicitydev.com/oauth/v1/get_access_token_by_saml'
   * base_url: 'https://api.finicitydev.com/financialdatafeed/v1'

If these parameters aren't specified than the default Intuit URLs are used instead.