### PR TITLE
add support for http proxy

### DIFF
--- a/lib/aggcat/base.rb
+++ b/lib/aggcat/base.rb
@@ -99,8 +99,9 @@ module Aggcat
 
     def parse_xml(data)
       return data if data.nil? || data.to_s.empty?
+      data.force_encoding('UTF-8')
       $stdout.puts(data) if @verbose
-      @parser ||= XmlHasher::Parser.new(snakecase: true, ignore_namespaces: true)
+      @parser ||= XmlHasher::Parser.new(snakecase: false, ignore_namespaces: true)
       @parser.parse(data)
     end
   end

--- a/lib/aggcat/base.rb
+++ b/lib/aggcat/base.rb
@@ -41,7 +41,7 @@ module Aggcat
     end
 
     def oauth_consumer
-      @oauth_consumer ||= OAuth::Consumer.new(@consumer_key, @consumer_secret, {timeout: @read_timeout, open_timeout: @open_timeout, verbose: @verbose})
+      @oauth_consumer ||= OAuth::Consumer.new(@consumer_key, @consumer_secret, {timeout: @read_timeout, open_timeout: @open_timeout, verbose: @verbose, proxy: @proxy})
     end
 
     def oauth_token(force=false)
@@ -55,7 +55,7 @@ module Aggcat
 
     def new_token(message)
       uri = URI.parse(@oauth_url)
-      http = Net::HTTP.new(uri.host, uri.port)
+      http = http_object(uri)
       request = Net::HTTP::Post.new(uri.request_uri)
       request['Authorization'] = %[OAuth oauth_consumer_key="#{@consumer_key}"]
       request.set_form_data({:saml_assertion => message})
@@ -65,6 +65,15 @@ module Aggcat
       response = http.request(request)
       params = CGI::parse(response.body)
       [params['oauth_token'][0], params['oauth_token_secret'][0]]
+    end
+
+    def http_object(our_uri)
+      if @proxy.nil?
+        http_object = Net::HTTP.new(our_uri.host, our_uri.port)
+      else
+        proxy_uri = @proxy.is_a?(URI) ? @proxy : URI.parse(@proxy)
+        http_object = Net::HTTP.new(our_uri.host, our_uri.port, proxy_uri.host, proxy_uri.port, proxy_uri.user, proxy_uri.password)
+      end
     end
 
     def saml_message(user_id)

--- a/lib/aggcat/configurable.rb
+++ b/lib/aggcat/configurable.rb
@@ -1,7 +1,7 @@
 module Aggcat
   module Configurable
 
-    KEYS = [:oauth_url, :base_url, :issuer_id, :consumer_key, :consumer_secret, :certificate_value, :certificate_password, :certificate_path, :customer_id, :open_timeout, :read_timeout, :verbose]
+    KEYS = [:oauth_url, :base_url, :issuer_id, :consumer_key, :consumer_secret, :certificate_value, :certificate_password, :certificate_path, :customer_id, :open_timeout, :read_timeout, :verbose, :proxy]
 
     attr_writer *KEYS
 

--- a/test/aggcat/aggcat_test.rb
+++ b/test/aggcat/aggcat_test.rb
@@ -25,6 +25,7 @@ class AggcatTest < Test::Unit::TestCase
       config.certificate_path = "#{fixture_path}/cert.key"
       config.open_timeout = 5
       config.read_timeout = 30
+      config.proxy = ENV['AGGCAT_PROXY']
     end
     assert_equal OAUTH_URL, configurable.instance_variable_get(:'@oauth_url')
     assert_equal BASE_URL, configurable.instance_variable_get(:'@base_url')
@@ -34,6 +35,7 @@ class AggcatTest < Test::Unit::TestCase
     assert_equal "#{fixture_path}/cert.key", configurable.instance_variable_get(:'@certificate_path')
     assert_equal 5, configurable.instance_variable_get(:'@open_timeout')
     assert_equal 30, configurable.instance_variable_get(:'@read_timeout')
+    assert_equal ENV['AGGCAT_PROXY'], configurable.instance_variable_get(:'@proxy')
   end
 
   def test_configure_certificate_by_value


### PR DESCRIPTION
Finicity requires whitelisted IP addresses, so putting
a proxy in front of your web workers makes that easier
to manage.
